### PR TITLE
Reference data status display + 'Update Now' button

### DIFF
--- a/NHSCovidPassVerifier/App.xaml
+++ b/NHSCovidPassVerifier/App.xaml
@@ -59,6 +59,7 @@
             
             <!-- Others -->
             <Color x:Key="NhsBlue">#005EB8</Color>
+            <Color x:Key="NhsGlowBlue">#358fe6</Color>
             <Color x:Key="NhsButtonGreen">#007F3B</Color>
             <Color x:Key="NhsTextBlack">#030303</Color>
             <Color x:Key="NhsDarkGray">#425563</Color>

--- a/NHSCovidPassVerifier/Locales/en.json
+++ b/NHSCovidPassVerifier/Locales/en.json
@@ -7,6 +7,11 @@
   "PERMISSIONS_MISSING_TITLE": "Permissions needed",
   "PERMISSIONS_MISSING_DESCRIPTION_SCANNER": "To use verifier, NHS COVID Pass Verifier needs permission to access your camera. Please go into your device settings and enable this.",
 
+  "DATA_UPDATE_LOADING": "Reference Data: Checking Status...",
+  "DATA_UPDATE_RUNNING": "Reference Data: Updating...",
+  "DATA_UPDATE_REQUIRED": "Reference Data: Update Required",
+  "DATA_UPDATE_NOT_REQUIRED": "Reference Data: Up To Date",
+  "DATA_UPDATE_UPDATE_NOW": "Update Now",
 
   "NHS_SPLASH_TEXT": "Please wait",
   "NHS_COVID_STATUS": "NHS COVID Pass",
@@ -182,7 +187,7 @@
   "INTERNATIONAL_SCANNER_RESULT_FIRST_POSITIVE_RESULT": "Date of test",
   "INTERNATIONAL_SCANNER_RESULT_COUNTRY_OF_TEST": "Country of test",
   "INTERNATIONAL_SCANNER_RESULT_DATE_VALID_UNTIL": "Recovery expiry",
-  
+
   "INTERNATIONAL_SCANNER_RESULT_RESULT_TEST": "Test",
   "INTERNATIONAL_SCANNER_RESULT_RESULT_TEST_TYPE": "Test type",
   "INTERNATIONAL_SCANNER_RESULT_RESULT_TEST_NAME": "Test name",

--- a/NHSCovidPassVerifier/ViewModels/LandingViewModel.cs
+++ b/NHSCovidPassVerifier/ViewModels/LandingViewModel.cs
@@ -13,22 +13,37 @@ namespace NHSCovidPassVerifier.ViewModels
     public class LandingViewModel : BaseViewModel
     {
         private readonly ISecureStorageService<TermsAndConditionsAgreed> _secureStorageService;
+        private readonly IJwkService _jwks;
+
         public string LandingsPageImageSource { get; }
         public string OpenScannerText { get; set; }
 
+        public string ReferenceDataStatusText { get; set; }
+        public bool ReferenceDataUpdateRequired { get; set; }
+
         public ICommand NextPageCommand => new AsyncCommand(async () => await ExecuteOnceAsync(NextPage));
 
-        public LandingViewModel(ISecureStorageService<TermsAndConditionsAgreed> secureStorageService)
+        public ICommand UpdateReferenceDataCommand => new AsyncCommand(
+            async () => await ExecuteOnceAsync(UpdateReferenceData),
+            () => ReferenceDataUpdateRequired
+        );
+
+        public LandingViewModel(ISecureStorageService<TermsAndConditionsAgreed> secureStorageService, IJwkService jwks)
         {
             _secureStorageService = secureStorageService;
+            _jwks = jwks;
             
             LandingsPageImageSource = "nhs_logo_white.png";
+            
             InitText();
+            RefreshReferenceDataStatusText();
+        
         }
 
         private void InitText()
         {
             OpenScannerText = "LANDING_PAGE_QR_CODE".Translate();
+            ReferenceDataStatusText = "DATA_UPDATE_LOADING".Translate();
         }
 
         private async Task NextPage()
@@ -70,5 +85,64 @@ namespace NHSCovidPassVerifier.ViewModels
         {
             await _navigationService.PushPage(new AboutPage(),false,true);
         }
+    
+        /// <summary>
+        /// Refreshes the 'Data Last Updated' value displayed
+        /// </summary>
+        /// <returns></returns>
+        private async Task RefreshReferenceDataStatusText()
+        {
+            ReferenceDataStatusText = "DATA_UPDATE_LOADING".Translate();
+            RaisePropertyChanged(() => ReferenceDataStatusText);
+
+            bool updateRequired = false;
+
+            bool jwkDataPresent = await _jwks.JwkListPresent();
+            
+            if (!jwkDataPresent)
+            {
+                updateRequired = true;
+            } 
+            else
+            {
+                updateRequired = await _jwks.JwkListNeedsUpdating();
+            }
+
+            // Push into status prop
+            if (updateRequired)
+            {
+                ReferenceDataStatusText = "DATA_UPDATE_REQUIRED".Translate();
+            } else
+            {
+                ReferenceDataStatusText = "DATA_UPDATE_NOT_REQUIRED".Translate();
+            }
+            RaisePropertyChanged(() => ReferenceDataStatusText);
+
+            // Set the property backing CanExecute of the Update command
+            ReferenceDataUpdateRequired = updateRequired;
+            RaisePropertyChanged(() => ReferenceDataUpdateRequired);
+        }
+
+        private async Task UpdateReferenceData()
+        {
+            ReferenceDataStatusText = "DATA_UPDATE_RUNNING".Translate();
+            RaisePropertyChanged(() => ReferenceDataStatusText);
+
+            bool updateSuccess = await _jwks.UpdateJwkList();
+            if (updateSuccess)
+            {
+                ReferenceDataUpdateRequired = false;
+                ReferenceDataStatusText = "DATA_UPDATE_NOT_REQUIRED".Translate();
+            } 
+            else
+            {
+                ReferenceDataUpdateRequired = true;
+                ReferenceDataStatusText = "DATA_UPDATE_REQUIRED".Translate();
+            }
+
+            RaisePropertyChanged(() => ReferenceDataStatusText);
+            RaisePropertyChanged(() => ReferenceDataUpdateRequired);
+        }
+
     }
 }

--- a/NHSCovidPassVerifier/Views/LandingPage.xaml
+++ b/NHSCovidPassVerifier/Views/LandingPage.xaml
@@ -13,6 +13,7 @@
         <Grid Padding="0, 0, 0, 30">
             <Grid.RowDefinitions>
                 <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
 
@@ -25,8 +26,33 @@
                 Scale="0.95">
             </Image>
 
+            <Grid Grid.Row="1"
+                Margin="30, 0, 30, 0">
+
+                <Frame
+                    CornerRadius="5"
+                    HasShadow="False"
+                    Padding="20"
+                    BorderColor="{StaticResource NhsGlowBlue}"
+                    BackgroundColor="Transparent"
+                    AutomationProperties.IsInAccessibleTree="True"
+                    AutomationId="LandingPage_CheckaQRCode"
+                    AutomationProperties.HelpText="{Binding ReferenceDataStatusText}">
+                    
+                    <Grid VerticalOptions="Center">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        
+                        <Label Grid.Column="0" VerticalOptions="Center" Text="{Binding ReferenceDataStatusText}" />
+                        <Button Grid.Column="1" Text="Update Now" Command="{Binding UpdateReferenceDataCommand}" />
+                    </Grid>
+                </Frame>
+            </Grid>
+
             <Grid 
-                Grid.Row="1"
+                Grid.Row="2"
                 Margin="30, 0, 30, 0">
 
                 <Frame CornerRadius="5"


### PR DESCRIPTION
Certain groups have been quick to point out that the app requires an internet connection. It's obvious to us all why this is required, however the current implementation is not explicit about when data is requested from a remote server. This PR begins a process of making any download of keys an action a user explicitly chooses to undertake.

By pulling the keys from the API at startup without making it an explicit user action, it is inviting certain groups to claim 'the app is sending and receiving data in the background'. They're _technically_ correct - though are really missing the point.

This PR adds a callout to the Landing Page showing the current status of the Reference Data used to support scanning (ie. the keys downloaded periodically). The user is also presented with a button allowing them to explicitly fetch data.

A further PR to remove all automated downloaded of data (eg at app startup) will be submitted shortly, with some additional UX around prompting to refresh data if required before entering the scanning page.

Happy to add those additional changes on this branch before merge if that's what is wanted.