### PR TITLE
Fix ValidQrShouldBePassedToValidatorCorrectly() tests

### DIFF
--- a/NHSCovidPassVerifier.Tests/ServicesTests/RepositoriesTests/QrDecoderServiceTests.cs
+++ b/NHSCovidPassVerifier.Tests/ServicesTests/RepositoriesTests/QrDecoderServiceTests.cs
@@ -144,7 +144,7 @@ namespace NHSCovidPassVerifier.Tests.RepositoryTests
             var split = validQr.Split(".");
 
             var hasher = new SHA256CryptoServiceProvider();
-            var digest = hasher.ComputeHash(Encoding.Unicode.GetBytes($"{split[0]}.{split[1]}"));
+            var digest = Encoding.Unicode.GetBytes($"{split[0]}.{split[1]}");
             var header = split[0];
             var sigBytes = Base64UrlEncoder.DecodeBytes(split[2]);
 


### PR DESCRIPTION
 ValidQrShouldBePassedToValidatorCorrectly() would not pass when run independently because _mockQrValidatorService would not be set up correctly. It would pass if run after any other test in its fixture, because _mockQrValidatorService.ValidateQrCodeForDomesticCertificate would be configured to always return true.

- Fix _mockQrValidatorService setup